### PR TITLE
Stick with webpack 1.x for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "strict-loader": "*",
     "style-loader": "^0.13.1",
     "uglify-js": "*",
-    "webpack": ">1.13.0"
+    "webpack": ">1.13.0 <2.0"
   }
 }


### PR DESCRIPTION
Current webpack 2.x does not support a lot of the directives in our
webpack.config.js any more: "jshint", "modulesDirectories", "root", and
"preLoaders". Add "< 2.0" version restriction to keep the pack
buildable.

---

Right now building this module is rather broken:
```
node_modules/.bin/webpack  
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'jshint'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   For typos: please correct them.
   For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
     Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
     plugins: [
       new webpack.LoaderOptionsPlugin({
         // test: /\.xxx$/, // may apply this only for some modules
         options: {
           jshint: ...
         }
       })
     ]
 - configuration.module has an unknown property 'preLoaders'. These properties are valid:
   object { exprContextCritical?, exprContextRecursive?, exprContextRegExp?, exprContextRequest?, loaders?, noParse?, rules?, unknownContextCritical?, unknownContextRecursive?, unknownContextRegExp?, unknownContextRequest?, unsafeCache?, wrappedContextCritical?, wrappedContextRecursive?, wrappedContextRegExp?, strictExportPresence? }
   Options affecting the normal modules (`NormalModuleFactory`).
 - configuration.resolve has an unknown property 'modulesDirectories'. These properties are valid:
   object { alias?, aliasFields?, cachePredicate?, descriptionFiles?, enforceExtension?, enforceModuleExtension?, extensions?, fileSystem?, mainFields?, mainFiles?, moduleExtensions?, modules?, plugins?, resolver?, symlinks?, unsafeCache?, useSyncFileSystemCalls? }
 - configuration.resolveLoader has an unknown property 'root'. These properties are valid:
   object { alias?, aliasFields?, cachePredicate?, descriptionFiles?, enforceExtension?, enforceModuleExtension?, extensions?, fileSystem?, mainFields?, mainFiles?, moduleExtensions?, modules?, plugins?, resolver?, symlinks?, unsafeCache?, useSyncFileSystemCalls? }
```

https://webpack.js.org/guides/migrating/ documents how to migrate some of it, but as a first bandaid I propose to just stick to webpack 1 for now. This will also help with compatibility with the packaged webpack in Fedora.